### PR TITLE
Experiment with build caching

### DIFF
--- a/.github/workflows/debug-image.yaml
+++ b/.github/workflows/debug-image.yaml
@@ -85,6 +85,14 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+          cache-from: |
+            type=gha
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LEGACY }}:buildcache
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LEGACY }}:buildcache,mode=max,compression=zstd,oci-mediatypes=true
 
       - name: If failed to create the image, send alert msg to dev team.
         if: ${{ failure() }}
@@ -155,6 +163,14 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+          cache-from: |
+            type=gha
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max,compression=zstd,oci-mediatypes=true
 
       - name: If failed to create the image, send alert msg to dev team.
         if: ${{ failure() }}


### PR DESCRIPTION
The image build for this repo is very slow.  I'm attempting to speed it up with caching.

**Build process improvements:**

* Added `BUILDKIT_INLINE_CACHE=1` as a build argument to enable inline cache metadata for Docker builds, facilitating more efficient layer reuse. [[1]](diffhunk://#diff-ea68c88f4175815a5d042d2e941677606072144093c175f1b707b9fff8a1967aR88-R95) [[2]](diffhunk://#diff-ea68c88f4175815a5d042d2e941677606072144093c175f1b707b9fff8a1967aR166-R173)
* Configured `cache-from` to pull cache layers from both GitHub Actions and the Docker registry, increasing cache hit rates for legacy and current images. [[1]](diffhunk://#diff-ea68c88f4175815a5d042d2e941677606072144093c175f1b707b9fff8a1967aR88-R95) [[2]](diffhunk://#diff-ea68c88f4175815a5d042d2e941677606072144093c175f1b707b9fff8a1967aR166-R173)
* Configured `cache-to` to push cache layers to both GitHub Actions and the Docker registry, with maximum mode and zstd compression for optimized storage and retrieval. [[1]](diffhunk://#diff-ea68c88f4175815a5d042d2e941677606072144093c175f1b707b9fff8a1967aR88-R95) [[2]](diffhunk://#diff-ea68c88f4175815a5d042d2e941677606072144093c175f1b707b9fff8a1967aR166-R173)