### PR TITLE
Add testssl.sh v3.2.3 to probe image

### DIFF
--- a/.github/workflows/debug-image.yaml
+++ b/.github/workflows/debug-image.yaml
@@ -57,6 +57,9 @@ jobs:
       - name: 'Test: Check if openssl is installed'
         run: docker run $IMAGE_NAME_LEGACY:$IMAGE_TAG_LEGACY which openssl
 
+      - name: 'Test: Check if testssl.sh is installed'
+        run: docker run $IMAGE_NAME_LEGACY:$IMAGE_TAG_LEGACY testssl.sh --version
+
       - name: Authenticate against Quay.io
         uses: docker/login-action@v4
         with:
@@ -137,6 +140,9 @@ jobs:
 
       - name: 'Test: Check if openssl is installed'
         run: docker run $IMAGE_NAME:$IMAGE_TAG which openssl
+
+      - name: 'Test: Check if testssl.sh is installed'
+        run: docker run $IMAGE_NAME:$IMAGE_TAG testssl.sh --version
 
       - name: Authenticate against Quay.io
         uses: docker/login-action@v4

--- a/.github/workflows/testssl-update.yaml
+++ b/.github/workflows/testssl-update.yaml
@@ -1,0 +1,93 @@
+name: Update testssl.sh version
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update-testssl:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
+    name: Check for new testssl.sh release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+
+      - name: Determine current and latest testssl.sh versions
+        id: versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          CURRENT=$(grep -oP 'TESTSSL_VERSION=\K[^\s]+' Dockerfile | head -1)
+          echo "current=${CURRENT}" >> "$GITHUB_OUTPUT"
+
+          LATEST=""
+          for attempt in {1..5}; do
+            set +e
+            LATEST=$(gh release list -R testssl/testssl.sh --limit 5 --json tagName,isLatest,isPrerelease \
+              --jq '[.[] | select(.isLatest and (.isPrerelease | not))] | .[0].tagName')
+            rc=$?
+            set -e
+            if [[ ${rc} -eq 0 && -n "${LATEST}" ]]; then break; fi
+            SLEEP=$((2 ** (attempt - 1)))
+            echo "Attempt ${attempt} failed. Retrying in ${SLEEP}s..."
+            sleep "${SLEEP}"
+          done
+
+          if [[ -z "${LATEST}" || "${LATEST}" == "null" ]]; then
+            echo "Failed to resolve latest testssl.sh tag" >&2
+            exit 1
+          fi
+          echo "latest=${LATEST}" >> "$GITHUB_OUTPUT"
+
+          if [[ "${CURRENT}" == "${LATEST}" ]]; then
+            echo "Already at latest (${LATEST})."
+            echo "should_update=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_update=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Stop if already up to date
+        if: steps.versions.outputs.should_update == 'false'
+        run: echo "No update needed"
+
+      - name: Update Dockerfile
+        if: steps.versions.outputs.should_update == 'true'
+        run: |
+          set -euo pipefail
+          LATEST=${{ steps.versions.outputs.latest }}
+          sed -i "s|TESTSSL_VERSION=.*|TESTSSL_VERSION=${LATEST}|" Dockerfile
+          echo "Updated testssl.sh to ${LATEST}:"
+          git --no-pager diff -- Dockerfile | cat
+
+      - name: Build image to verify
+        if: steps.versions.outputs.should_update == 'true'
+        run: docker build -t certsuite-probe:testssl-test .
+
+      - name: Verify testssl.sh works
+        if: steps.versions.outputs.should_update == 'true'
+        run: docker run --rm certsuite-probe:testssl-test testssl.sh --version
+
+      - name: Create PR
+        if: steps.versions.outputs.should_update == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update testssl.sh to ${{ steps.versions.outputs.latest }}"
+          title: "Update testssl.sh to ${{ steps.versions.outputs.latest }}"
+          body: |
+            Bumps testssl.sh from `${{ steps.versions.outputs.current }}` to `${{ steps.versions.outputs.latest }}`.
+
+            Release: https://github.com/testssl/testssl.sh/releases/tag/${{ steps.versions.outputs.latest }}
+          branch: update-testssl-${{ steps.versions.outputs.latest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,15 @@ RUN \
 	&& make
 
 FROM registry.access.redhat.com/ubi9/ubi:9.7-1777525589
+
+ARG TESTSSL_VERSION=v3.2.3
 # hadolint ignore=DL3041
 RUN \
 	dnf update --assumeyes --disableplugin=subscription-manager \
 	&& dnf install --assumeyes --disableplugin=subscription-manager \
 		ethtool \
 		golang \
+		hostname \
 		iproute \
 		iptables \
 		iputils \
@@ -36,10 +39,22 @@ RUN \
 		nftables \
 		pciutils \
 		procps-ng \
+		bind-utils \
+		socat \
 		util-linux \
 	&& dnf clean all --assumeyes --disableplugin=subscription-manager \
 	&& rm -fr /var/cache/yum \
 	&& mkdir /root/podman
+
+# Install testssl.sh from pinned release
+# hadolint ignore=DL3003
+RUN curl -sL "https://github.com/testssl/testssl.sh/archive/refs/tags/${TESTSSL_VERSION}.tar.gz" \
+		-o /tmp/testssl.tar.gz \
+	&& mkdir -p /opt/testssl \
+	&& tar -xzf /tmp/testssl.tar.gz -C /opt/testssl --strip-components=1 \
+	&& chmod +x /opt/testssl/testssl.sh \
+	&& ln -s /opt/testssl/testssl.sh /usr/local/bin/testssl.sh \
+	&& rm -f /tmp/testssl.tar.gz
 # Set the GOPATH environment variable
 ENV GOPATH=/go
 # Add the Go binary directory to the PATH


### PR DESCRIPTION
## Summary

- Install [testssl.sh v3.2.3](https://github.com/testssl/testssl.sh/releases/tag/v3.2.3) into the probe container image from a pinned GitHub release tarball
- Add `bind-utils`, `socat`, and `hostname` packages required by testssl.sh
- Pin the version via a Dockerfile `ARG` for easy bumping
- Add a daily GitHub Actions workflow (`testssl-update.yaml`) that checks for new stable testssl.sh releases and opens a version-bump PR automatically
- Add `testssl.sh --version` verification to both image CI jobs in `debug-image.yaml`

## Why

The certsuite `networking-tls-minimum-version` test is adding an optional `--tls-probe-method=testssl` flag that uses testssl.sh for deeper TLS auditing (full protocol and cipher enumeration). This requires testssl.sh to be available in the probe container.

See the [timing comparison gist](https://gist.github.com/sebrandon1/d73fd2bda7a3b28bc5fc615fb408c948) for context on why testssl.sh is opt-in rather than the default (it is ~40x slower than the openssl exec probes).

## Test plan

- [x] docker build succeeds with testssl.sh installed
- [x] testssl.sh --version prints v3.2.3 inside the container
- [x] which dig confirms bind-utils is present
- [x] Existing image tests (lscpu, lsblk, lspci, ping, ip, openssl) still pass
- [ ] testssl-update workflow runs successfully via workflow_dispatch